### PR TITLE
Use `/web/2oe_/` in the URL instead of `/web/0oe_/`

### DIFF
--- a/youtube_wayback.py
+++ b/youtube_wayback.py
@@ -4,7 +4,7 @@ import requests
 import sys
 
 _RE_VALID_URL = re.compile(r'(?:(?:https?://(?:www\.)?)?(?:youtube\.com/watch\?v=|youtu\.be/))?(?P<video_id>[a-zA-Z0-9_-]{11})')
-_WAYBACK_URL = 'https://web.archive.org/web/0oe_/http://wayback-fakeurl.archive.org/yt/{video_id}'
+_WAYBACK_URL = 'https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/{video_id}'
 
 def youtube_wayback(video_id, session=None):
     session = session or requests.Session()


### PR DESCRIPTION
Fixes #1 (I think).

In the Wayback Machine `/web/0/{url}` means the first archive of a URL and `/web/2/{url}` means the most recent archive of a URL. `oe_` tells it to respond with the raw media, not the media embedded in an iframe.

I have no idea why this fixes #1. Sometimes `/web/0oe_/` worked and sometimes it didn't, and sometimes it worked in browser but not with python-requests. I tried sending different browser headers to see if that fixed it, but I couldn't figure it out.